### PR TITLE
Add `backend/bin` to `.gitignore`

### DIFF
--- a/backend/.gitignore
+++ b/backend/.gitignore
@@ -1,7 +1,7 @@
 **.env
 !.env.example
 
-.DS_Store
+**.DS_Store
 
-bin/*
-!bin/.keep
+**/bin/*
+**/bin/.keep


### PR DESCRIPTION
# Description

Moving files to the backend requires some changes to the `.gitignore`. These changes were not previously included and allowed binaries generated to the `backend/bin/` directory to be included in subsequent git commits. This changes fixes that issue.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)