### PR TITLE
Enable client side routing

### DIFF
--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,8 +1,20 @@
+# Build flutter project
 FROM --platform=$BUILDPLATFORM ghcr.io/cirruslabs/flutter:stable AS build
 WORKDIR /app
 COPY . .
 RUN flutter build web
 
+
+# Serve project with nginx
 FROM nginx:alpine
-EXPOSE 80
+ARG NGINX_HOST
+EXPOSE $NGINX_PORT
+
+# Copy nginx files
 COPY --from=build /app/build/web /usr/share/nginx/html
+COPY --from=build /app/nginx/templates/* /etc/nginx/templates/
+COPY --from=build /app/nginx/nginx.conf /etc/nginx/nginx.conf
+
+# Set template variables
+ENV NGINX_HOST=$NGINX_HOST
+ENV NGINX_PORT=80

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -10,7 +10,9 @@ PLATFORM ?= linux/arm64
 
 docker:
 	@echo "Building $(BUILD_NAME)"
-	docker buildx build --platform $(PLATFORM) -t $(BUILD_NAME) .
+	host=$$(../scripts/generate-subdomain.sh).deguzman.cloud && \
+        if [[ host == "main" ]]; then host="boshi.deguzman.cloud"; fi && \
+		   docker buildx build --build-arg NGINX_HOST=$${host} --platform $(PLATFORM) -t $(BUILD_NAME) .
 
 docker-push:
 	@echo "Pushing $(BUILD_NAME):$(tag)"

--- a/frontend/nginx/nginx.conf
+++ b/frontend/nginx/nginx.conf
@@ -1,0 +1,30 @@
+user  nginx;
+worker_processes  auto;
+
+error_log  /var/log/nginx/error.log notice;
+pid        /var/run/nginx.pid;
+
+
+events {
+    worker_connections  1024;
+}
+
+http {
+    include       /etc/nginx/mime.types;
+    default_type  application/octet-stream;
+    tcp_nodelay on;
+    types_hash_max_size 2048;
+
+    log_format  main  '$remote_addr - $remote_user [$time_local] "$request" '
+                    '$status $body_bytes_sent "$http_referer" '
+                    '"$http_user_agent" "$http_x_forwarded_for"';
+
+    access_log  /var/log/nginx/access.log  main;
+
+    sendfile        on;
+    tcp_nopush     on;
+
+    keepalive_timeout  65;
+
+    include /etc/nginx/conf.d/*.conf;
+}

--- a/frontend/nginx/templates/default.conf.template
+++ b/frontend/nginx/templates/default.conf.template
@@ -1,0 +1,32 @@
+server {
+    listen ${NGINX_PORT};
+    server_name localhost;
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Redirect to /index.html for flutter client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static files for better performance
+    location ~* \.(?:ico|css|js|gif|jpe?g|pngwebp#|woff2?|eot|ttf|svg|wasm)$ {
+        expires 6M;
+        access_log off;
+        add_header Cache-Control "public, max-age=15724800, immutable";
+    }
+
+    # WebAssembly support
+    location ~* \.wasm$ {
+        default_type application/wasm;
+        expires 6M;
+        access_log off;
+        add_header Cache-Control "public, max-age=15724800, immutable";
+    }
+
+    # Gzip compression for Flutter Web assets
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript #text/xml pplication/xml application/xml+rss #text/javascript;
+    gzip_vary on;
+}

--- a/frontend/nginx/templates/server.conf.template
+++ b/frontend/nginx/templates/server.conf.template
@@ -1,0 +1,32 @@
+server {
+    listen ${NGINX_PORT};
+    server_name ${NGINX_HOST};
+
+    root /usr/share/nginx/html;
+    index index.html;
+
+    # Redirect to /index.html for flutter client-side routing
+    location / {
+        try_files $uri $uri/ /index.html;
+    }
+
+    # Cache static files for better performance
+    location ~* \.(?:ico|css|js|gif|jpe?g|pngwebp#|woff2?|eot|ttf|svg|wasm)$ {
+        expires 6M;
+        access_log off;
+        add_header Cache-Control "public, max-age=15724800, immutable";
+    }
+
+    # WebAssembly support
+    location ~* \.wasm$ {
+        default_type application/wasm;
+        expires 6M;
+        access_log off;
+        add_header Cache-Control "public, max-age=15724800, immutable";
+    }
+
+    # Gzip compression for Flutter Web assets
+    gzip on;
+    gzip_types text/plain text/css application/json application/javascript #text/xml pplication/xml application/xml+rss #text/javascript;
+    gzip_vary on;
+}


### PR DESCRIPTION
# Description

The previous nginx configuration did not allow routing for the flutter project. Two template configurations `server.conf.template` and `default.conf.template` were introduced to enable client side routing. The introduced line is

```
location / {
  try_files $uri $uri/ /index.html
}
```

which redirects all not found routes to the root page, allowing flutter to handle the routing on the client side.

This bug-fix allows us to access the `/login` page and other routes.

## Environment variables

Additionally, the `NGINX_PORT` and `NGINX_HOST` environment variables were introduced to the build so the nginx image can run `envsubst` on the template files with the supplied values. This makes the configuration more accessible through the build and allows branch previews to work since the subdomain can be specified as a build arg in the Dockerfile.

Fixes # (issue)
N/A

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)