### PR TITLE
Bug Fix. OAuth session wasn't storing properly, now it is but it's less clean.

### DIFF
--- a/frontend/lib/src/model/oauth/oauth_service.dart
+++ b/frontend/lib/src/model/oauth/oauth_service.dart
@@ -106,8 +106,19 @@ class OAuthService {
   Future<void> setSessionVars(OAuthSession session) async {
     try {
       final SharedPreferences prefs = await SharedPreferences.getInstance();
-      await prefs.setString("session-vars",
-          "{\"accessToken\": \"${session.accessToken}\", \"refreshToken\": \"${session.refreshToken}\", \"tokenType\": \"${session.tokenType}\", \"scope\": \"${session.scope}\", \"expiresAt\": \"${session.expiresAt.toString()}\", \"sub\": \"${session.sub}\", \"\$dPoPNonce\": \"${session.$dPoPNonce}\", \"\$publicKey\": \"${session.$publicKey}\", \"\$privateKey\": \"${session.$privateKey}\"}");
+      await prefs.setString(
+          "session-vars",
+          json.encode({
+            "accessToken": session.accessToken,
+            "refreshToken": session.refreshToken,
+            "tokenType": session.tokenType,
+            "scope": session.scope,
+            "expiresAt": session.expiresAt.toString(),
+            "sub": session.sub,
+            "\$dPoPNonce": session.$dPoPNonce,
+            "\$publicKey": session.$publicKey,
+            "\$privateKey": session.$privateKey,
+          }));
     } catch (e) {
       rethrow;
     }

--- a/frontend/lib/src/model/oauth/oauth_service.dart
+++ b/frontend/lib/src/model/oauth/oauth_service.dart
@@ -1,4 +1,5 @@
 import 'dart:convert';
+import 'dart:js_interop';
 
 import 'package:http/http.dart' as http;
 import 'package:shared_preferences/shared_preferences.dart';
@@ -105,14 +106,8 @@ class OAuthService {
   Future<void> setSessionVars(OAuthSession session) async {
     try {
       final SharedPreferences prefs = await SharedPreferences.getInstance();
-      await prefs.setString(
-          "session-vars",
-          json.encode(
-            session,
-            toEncodable: (object) {
-              return object.toString();
-            },
-          ));
+      await prefs.setString("session-vars",
+          "{\"accessToken\": \"${session.accessToken}\", \"refreshToken\": \"${session.refreshToken}\", \"tokenType\": \"${session.tokenType}\", \"scope\": \"${session.scope}\", \"expiresAt\": \"${session.expiresAt.toString()}\", \"sub\": \"${session.sub}\", \"\$dPoPNonce\": \"${session.$dPoPNonce}\", \"\$publicKey\": \"${session.$publicKey}\", \"\$privateKey\": \"${session.$privateKey}\"}");
     } catch (e) {
       rethrow;
     }


### PR DESCRIPTION
# Description

The encode was encoding the object as "instance of object" and I didn't see that it was doing that. Now it's storing the object itself.

Fixes # (issue)
N/A
## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
