### PR TITLE
fix: use correct substitution to reference branch-name input

### DIFF
--- a/.github/actions/build-info/action.yaml
+++ b/.github/actions/build-info/action.yaml
@@ -21,5 +21,5 @@ runs:
       run: |
         filtered_branch_name=$(echo "${{inputs.branch-name}}" | tr '[:upper:]' '[:lower:]' | sed 's/[^a-z0-9]/-/g' | sed 's/--*/-/g' | sed -E 's/^-+|-+$//g')
 
-        echo "namespace=$([[ "${inputs.branch-name}" == "main" ]] && echo "boshi" || echo "boshi-${filtered_branch_name}")" >> $GITHUB_OUTPUT
+        echo "namespace=$([[ "${{inputs.branch-name}}" == "main" ]] && echo "boshi" || echo "boshi-${filtered_branch_name}")" >> $GITHUB_OUTPUT
         echo "branch-name=${filtered_branch_name}" >> $GITHUB_OUTPUT

--- a/.github/actions/k8s/deploy/action.yaml
+++ b/.github/actions/k8s/deploy/action.yaml
@@ -21,7 +21,7 @@ inputs:
     required: true
   namespace:
     description: "Kubernetes namespace"
-    required: false
+    required: true
   config-envs:
     description: "Additional environment variables for the K8s config"
     required: false


### PR DESCRIPTION
# Description

The CD pipeline for both pushing and deleting branches were broken. No namespaces were being provided causing the creation and deletion of namespaces to fail. The root cause was because the action that generated the namespace `build-info` was incorrectly referencing the `branch-name` incorrectly causing the action to fail and no namespace to be generated.

This PR correctly references `inputs.branch-name` and fixes the issue.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)