### PR TITLE
ops: extend post table and add reaction table

### DIFF
--- a/explorer/Makefile
+++ b/explorer/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all build docker docker-push generate clean
+.PHONY: all build sqlc docker docker-push generate clean
 
 DOCKER_REGISTRY ?= matthew10125
 IMAGE_NAME ?= boshi-explorer
@@ -21,6 +21,10 @@ all:
 build:
 	@echo "Building the application..."
 	CGO_ENABLED=0 GOOS=$(TARGETOS) GOARCH=$(TARGETARCH) go build -o bin/boshi-explorer cmd/main.go
+
+sqlc:
+	@echo "Generating SQLC..."
+	cd sql && sqlc generate
 
 docker:
 	@echo "Building $(BUILD_NAME)..."

--- a/explorer/cmd/main.go
+++ b/explorer/cmd/main.go
@@ -16,6 +16,7 @@ import (
 	"github.com/bluesky-social/indigo/events"
 	"github.com/bluesky-social/indigo/events/schedulers/sequential"
 	"github.com/gorilla/websocket"
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 var log = logger.GetLogger()
@@ -46,7 +47,10 @@ func main() {
 				if strings.HasPrefix(op.Path, "app.boshi.feed") {
 					uri := fmt.Sprintf("at://%s/%s", evt.Repo, op.Path)
 					log.Info("New Activity @", "uri", uri)
-					queries.CreatePost(context.Background(), dbutil.CreatePostParams{Uri: uri, Cid: op.Cid.String(), IndexedAt: time.Now().String()})
+					queries.CreatePost(context.Background(), dbutil.CreatePostParams{Uri: uri, Cid: op.Cid.String(), IndexedAt: pgtype.Timestamptz{
+						Time:  time.Now(),
+						Valid: true,
+					}})
 					log.Info("Post created", "uri", uri)
 				}
 			}

--- a/explorer/sql/dbutil/models.go
+++ b/explorer/sql/dbutil/models.go
@@ -9,13 +9,12 @@ import (
 )
 
 type Post struct {
-	Uri            string
-	Cid            string
-	AuthorDid      string
-	IndexedAt      pgtype.Timestamptz
-	Title          string
-	Content        string
-	ReplyToPostCid pgtype.Text
+	Uri       string
+	Cid       string
+	AuthorDid string
+	IndexedAt pgtype.Timestamptz
+	Title     string
+	Content   string
 }
 
 type Reaction struct {
@@ -24,4 +23,14 @@ type Reaction struct {
 	AuthorDid string
 	IndexedAt pgtype.Timestamptz
 	Emote     string
+}
+
+type Reply struct {
+	Uri        string
+	Cid        string
+	AuthorDid  string
+	IndexedAt  pgtype.Timestamptz
+	Title      string
+	Content    string
+	ReplyToUri pgtype.Text
 }

--- a/explorer/sql/dbutil/models.go
+++ b/explorer/sql/dbutil/models.go
@@ -32,5 +32,5 @@ type Reply struct {
 	IndexedAt  pgtype.Timestamptz
 	Title      string
 	Content    string
-	ReplyToUri pgtype.Text
+	ReplyToUri string
 }

--- a/explorer/sql/dbutil/models.go
+++ b/explorer/sql/dbutil/models.go
@@ -4,8 +4,24 @@
 
 package dbutil
 
+import (
+	"github.com/jackc/pgx/v5/pgtype"
+)
+
 type Post struct {
+	Uri            string
+	Cid            string
+	AuthorDid      string
+	IndexedAt      pgtype.Timestamptz
+	Title          string
+	Content        string
+	ReplyToPostCid pgtype.Text
+}
+
+type Reaction struct {
 	Uri       string
-	Cid       string
-	IndexedAt string
+	PostUri   pgtype.Text
+	AuthorDid string
+	IndexedAt pgtype.Timestamptz
+	Emote     string
 }

--- a/explorer/sql/dbutil/query.sql.go
+++ b/explorer/sql/dbutil/query.sql.go
@@ -17,7 +17,7 @@ INSERT INTO post (
 ) VALUES (
   $1, $2, $3
 )
-RETURNING uri, cid, author_did, indexed_at, title, content, reply_to_post_cid
+RETURNING uri, cid, author_did, indexed_at, title, content
 `
 
 type CreatePostParams struct {
@@ -36,7 +36,6 @@ func (q *Queries) CreatePost(ctx context.Context, arg CreatePostParams) (Post, e
 		&i.IndexedAt,
 		&i.Title,
 		&i.Content,
-		&i.ReplyToPostCid,
 	)
 	return i, err
 }
@@ -52,7 +51,7 @@ func (q *Queries) DeletePost(ctx context.Context, uri string) error {
 }
 
 const getPost = `-- name: GetPost :one
-SELECT uri, cid, author_did, indexed_at, title, content, reply_to_post_cid FROM post
+SELECT uri, cid, author_did, indexed_at, title, content FROM post
 WHERE uri = $1 LIMIT 1
 `
 
@@ -66,13 +65,12 @@ func (q *Queries) GetPost(ctx context.Context, uri string) (Post, error) {
 		&i.IndexedAt,
 		&i.Title,
 		&i.Content,
-		&i.ReplyToPostCid,
 	)
 	return i, err
 }
 
 const listPosts = `-- name: ListPosts :many
-SELECT uri, cid, author_did, indexed_at, title, content, reply_to_post_cid FROM post
+SELECT uri, cid, author_did, indexed_at, title, content FROM post
 ORDER BY indexed_at
 `
 
@@ -92,7 +90,6 @@ func (q *Queries) ListPosts(ctx context.Context) ([]Post, error) {
 			&i.IndexedAt,
 			&i.Title,
 			&i.Content,
-			&i.ReplyToPostCid,
 		); err != nil {
 			return nil, err
 		}

--- a/explorer/sql/query.sql
+++ b/explorer/sql/query.sql
@@ -4,11 +4,11 @@ WHERE uri = $1 LIMIT 1;
 
 -- name: ListPosts :many
 SELECT * FROM post
-ORDER BY "indexedAt";
+ORDER BY indexed_at;
 
 -- name: CreatePost :one
 INSERT INTO post (
-  uri, cid, "indexedAt"
+  uri, cid, indexed_at
 ) VALUES (
   $1, $2, $3
 )

--- a/explorer/sql/schema.sql
+++ b/explorer/sql/schema.sql
@@ -15,8 +15,9 @@ CREATE TABLE reply (
     indexed_at TIMESTAMPTZ NOT NULL,
     title VARCHAR(511) NOT NULL,
     content VARCHAR(8191) NOT NULL,
-    reply_to_uri VARCHAR,
-    PRIMARY KEY (uri)
+    reply_to_uri VARCHAR NOT NULL,
+    PRIMARY KEY (uri),
+    FOREIGN KEY (reply_to_uri) REFERENCES post (uri)
 );
 
 CREATE TABLE reaction (

--- a/explorer/sql/schema.sql
+++ b/explorer/sql/schema.sql
@@ -1,6 +1,20 @@
--- TODO: refactor "indexedAt" to be a timestamp
 CREATE TABLE post (
-    uri VARCHAR PRIMARY KEY,
+    uri VARCHAR,
     cid VARCHAR NOT NULL,
-    "indexedAt" VARCHAR NOT NULL
+    author_did VARCHAR NOT NULL,
+    indexed_at TIMESTAMPTZ NOT NULL,
+    title VARCHAR(511) NOT NULL,
+    content VARCHAR(8191) NOT NULL,
+    reply_to_post_cid VARCHAR,
+    PRIMARY KEY (uri)
+);
+
+CREATE TABLE reaction (
+    uri VARCHAR,
+    post_uri VARCHAR,
+    author_did VARCHAR NOT NULL,
+    indexed_at TIMESTAMPTZ NOT NULL,
+    emote VARCHAR NOT NULL,
+    PRIMARY KEY (uri),
+    FOREIGN KEY (post_uri) REFERENCES post (uri)
 );

--- a/explorer/sql/schema.sql
+++ b/explorer/sql/schema.sql
@@ -5,7 +5,17 @@ CREATE TABLE post (
     indexed_at TIMESTAMPTZ NOT NULL,
     title VARCHAR(511) NOT NULL,
     content VARCHAR(8191) NOT NULL,
-    reply_to_post_cid VARCHAR,
+    PRIMARY KEY (uri)
+);
+
+CREATE TABLE reply (
+    uri VARCHAR,
+    cid VARCHAR NOT NULL,
+    author_did VARCHAR NOT NULL,
+    indexed_at TIMESTAMPTZ NOT NULL,
+    title VARCHAR(511) NOT NULL,
+    content VARCHAR(8191) NOT NULL,
+    reply_to_uri VARCHAR,
     PRIMARY KEY (uri)
 );
 

--- a/explorer/sql/schema.sql
+++ b/explorer/sql/schema.sql
@@ -17,7 +17,7 @@ CREATE TABLE reply (
     content VARCHAR(8191) NOT NULL,
     reply_to_uri VARCHAR NOT NULL,
     PRIMARY KEY (uri),
-    FOREIGN KEY (reply_to_uri) REFERENCES post (uri)
+    FOREIGN KEY (reply_to_uri) REFERENCES post (uri) ON DELETE CASCADE
 );
 
 CREATE TABLE reaction (
@@ -27,5 +27,5 @@ CREATE TABLE reaction (
     indexed_at TIMESTAMPTZ NOT NULL,
     emote VARCHAR NOT NULL,
     PRIMARY KEY (uri),
-    FOREIGN KEY (post_uri) REFERENCES post (uri)
+    FOREIGN KEY (post_uri) REFERENCES post (uri) ON DELETE CASCADE
 );


### PR DESCRIPTION
# Description

Extend the post table to include more relevant fields such as content and title. Added reply table and reaction table.

## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)
