### PR TITLE
fix: update deployment rollout conditions

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -33,7 +33,7 @@ jobs:
               - 'kubernetes/**'
       - name: Debug
         run: |
-          echo "${{ steps.filter.outputs.kubernetes_files }}"
+          echo "${{ contains( fromJson(steps.filter.outputs.kubernetes_files), 'kubernetes/backend.yaml' ) }}"
 
   build-info:
     name: Get Build Info

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,7 +12,6 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       explorer: ${{ steps.filter.outputs.explorer }}
       kubernetes: ${{ steps.filter.outputs.kubernetes }}
-      changed_files: ${{ steps.filter.outputs.changed_files }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3
@@ -94,7 +93,7 @@ jobs:
 
   build-and-deploy-backend:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.backend == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/backend.yaml') }}
+    if: ${{ needs.changes.outputs.backend == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.kubernetes_files, 'kubernetes/backend.yaml') }}
     name: Build and Deploy Backend
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -149,7 +148,7 @@ jobs:
 
   build-and-deploy-landing:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.landing == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/landing.yaml') }}
+    if: ${{ needs.changes.outputs.landing == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.kubernetes_files, 'kubernetes/landing.yaml') }}
     name: Build and Deploy Landing
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -204,7 +203,7 @@ jobs:
 
   build-and-deploy-frontend:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.frontend == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/frontend.yaml') }}
+    if: ${{ needs.changes.outputs.frontend == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.kubernetes_files, 'kubernetes/frontend.yaml') }}
     name: Build and Deploy Frontend
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -259,7 +258,7 @@ jobs:
 
   build-and-deploy-explorer:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.explorer == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/explorer.yaml')}}
+    if: ${{ needs.changes.outputs.explorer == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.kubernetes_files, 'kubernetes/explorer.yaml')}}
     name: Build and Deploy Explorer
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -143,7 +143,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{ needs.clone-repo.outputs.repo-destination }}/kubernetes/backend.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || format('{0}-latest', needs.build-info.outputs.branch-name) }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -198,7 +198,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/landing.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || format('{0}-latest', needs.build-info.outputs.branch-name) }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -253,7 +253,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/frontend.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || format('{0}-latest', needs.build-info.outputs.branch-name) }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -304,7 +304,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/explorer.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || format('{0}-latest', needs.build-info.outputs.branch-name) }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: POSTGRES_URL,SOCKET_URI,FIREHOSE_IDENTIFIER
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -33,7 +33,7 @@ jobs:
               - 'kubernetes/**'
       - name: Debug
         run: |
-          echo "${{ steps.filter.outputs.changed_files }}"
+          echo "${{ steps.filter.outputs.kubernetes_files }}"
 
   build-info:
     name: Get Build Info

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -91,7 +91,7 @@ jobs:
 
   build-and-deploy-backend:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.backend == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
+    if: ${{ needs.changes.outputs.backend == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/backend.yaml') }}
     name: Build and Deploy Backend
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -100,21 +100,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: backend
       - name: Push Docker Image with SHA Tag
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
+        if: ${{ needs.changes.outputs.backend == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -135,13 +139,13 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{ needs.clone-repo.outputs.repo-destination }}/kubernetes/backend.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.build-info.outputs.branch-name }}-latest
+          docker-image: ${{ env.build_name }}:${{ needs.changes.output.backend == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
   build-and-deploy-landing:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.landing == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
+    if: ${{ needs.changes.outputs.landing == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/landing.yaml') }}
     name: Build and Deploy Landing
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -150,21 +154,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: ${{ needs.changes.outputs.landing == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
+        if: ${{ needs.changes.outputs.landing == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: landing
       - name: Push Docker Image with SHA Tag
+        if: ${{ needs.changes.outputs.landing == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
+        if: ${{ needs.changes.outputs.landing == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -185,13 +193,13 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/landing.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.build-info.outputs.branch-name }}-latest
+          docker-image: ${{ env.build_name }}:${{ needs.changes.output.landing == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
   build-and-deploy-frontend:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.frontend == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
+    if: ${{ needs.changes.outputs.frontend == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/frontend.yaml') }}
     name: Build and Deploy Frontend
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -200,21 +208,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: frontend
       - name: Push Docker Image with SHA Tag
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
+        if: ${{ needs.changes.outputs.frontend == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -235,13 +247,13 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/frontend.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.build-info.outputs.branch-name }}-latest
+          docker-image: ${{ env.build_name }}:${{ needs.changes.output.frontend == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
   build-and-deploy-explorer:
     needs: [changes, build-info, clone-repo]
-    if: ${{ needs.changes.outputs.explorer == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
+    if: ${{ needs.changes.outputs.explorer == 'true' || needs.build-info.outputs.namespace-exists == 'false' || contains(needs.changes.outputs.changed_files, 'kubernetes/explorer.yaml')}}
     name: Build and Deploy Explorer
     runs-on: ubuntu-latest
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
@@ -250,21 +262,25 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
+        if: ${{ needs.changes.outputs.explorer == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
+        if: ${{ needs.changes.outputs.explorer == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: explorer
       - name: Push Docker Image with SHA Tag
+        if: ${{ needs.changes.outputs.explorer == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
+        if: ${{ needs.changes.outputs.explorer == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -281,7 +297,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/explorer.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.build-info.outputs.branch-name }}-latest
+          docker-image: ${{ env.build_name }}:${{ needs.changes.output.explorer == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: POSTGRES_URL,SOCKET_URI,FIREHOSE_IDENTIFIER
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -143,7 +143,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{ needs.clone-repo.outputs.repo-destination }}/kubernetes/backend.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -198,7 +198,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/landing.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -253,7 +253,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/frontend.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -304,7 +304,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/explorer.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join([needs.build-info.outputs.branch-name, '-latest'], '') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: POSTGRES_URL,SOCKET_URI,FIREHOSE_IDENTIFIER
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -33,7 +33,7 @@ jobs:
               - 'kubernetes/**'
       - name: Debug
         run: |
-          echo "${{ steps.filter.changed_files }}"
+          echo "${{ steps.filter.outputs.changed_files }}"
 
   build-info:
     name: Get Build Info

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -12,6 +12,7 @@ jobs:
       frontend: ${{ steps.filter.outputs.frontend }}
       explorer: ${{ steps.filter.outputs.explorer }}
       kubernetes: ${{ steps.filter.outputs.kubernetes }}
+      kubernetes_files: ${{ steps.filter.outputs.kubernetes_files }}
     steps:
       - uses: actions/checkout@v4
       - uses: dorny/paths-filter@v3

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -140,7 +140,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{ needs.clone-repo.outputs.repo-destination }}/kubernetes/backend.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_name == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -195,7 +195,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/landing.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_name == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -301,7 +301,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/explorer.yaml
-          docker-image: ${{ env.build_name }}:${{ env.build_name == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: POSTGRES_URL,SOCKET_URI,FIREHOSE_IDENTIFIER
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -97,28 +97,29 @@ jobs:
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     env:
       build_name: ${{vars.DOCKER_REGISTRY}}/boshi-backend
+      build_docker: ${{ needs.changes.outputs.backend == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: backend
       - name: Push Docker Image with SHA Tag
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
-        if: ${{ needs.changes.outputs.backend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -139,7 +140,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{ needs.clone-repo.outputs.repo-destination }}/kubernetes/backend.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.changes.output.backend == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_name == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -151,28 +152,29 @@ jobs:
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     env:
       build_name: ${{ vars.DOCKER_REGISTRY }}/boshi-landing
+      build_docker: ${{ needs.changes.outputs.landing == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
-        if: ${{ needs.changes.outputs.landing == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
-        if: ${{ needs.changes.outputs.landing == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: landing
       - name: Push Docker Image with SHA Tag
-        if: ${{ needs.changes.outputs.landing == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
-        if: ${{ needs.changes.outputs.landing == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -193,7 +195,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/landing.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.changes.output.landing == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_name == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -205,28 +207,29 @@ jobs:
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     env:
       build_name: ${{ vars.DOCKER_REGISTRY }}/boshi-frontend
+      build_docker: ${{ needs.changes.outputs.frontend == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: frontend
       - name: Push Docker Image with SHA Tag
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
-        if: ${{ needs.changes.outputs.frontend == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -247,7 +250,7 @@ jobs:
           port: ${{ secrets.SSH_PORT }}
           domain: ${{ steps.domain.outputs.domain }}.deguzman.cloud
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/frontend.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.changes.output.frontend == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: CLUSTER_ISSUER
 
@@ -259,28 +262,29 @@ jobs:
     environment: ${{ github.ref_name == 'main' && 'prod' || 'dev' }}
     env:
       build_name: ${{ vars.DOCKER_REGISTRY }}/boshi-explorer
+      build_docker: ${{ needs.changes.outputs.explorer == 'true' || needs.build-info.outputs.namespace-exists == 'false' }}
     steps:
       - uses: actions/checkout@v4
       - name: Login to Docker Hub
-        if: ${{ needs.changes.outputs.explorer == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: docker/login-action@v3
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build Docker Image
-        if: ${{ needs.changes.outputs.explorer == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/build
         with:
           build-name: ${{ env.build_name }}
           path: explorer
       - name: Push Docker Image with SHA Tag
-        if: ${{ needs.changes.outputs.explorer == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
           tag: ${{ github.sha }}
       - name: Push Docker Image with latest Tag
-        if: ${{ needs.changes.outputs.explorer == 'true' }}
+        if: ${{ env.build_docker == 'true' }}
         uses: ./.github/actions/docker/push
         with:
           build-name: ${{ env.build_name }}
@@ -297,7 +301,7 @@ jobs:
           key: ${{ secrets.SSH_KEY }}
           port: ${{ secrets.SSH_PORT }}
           config-path: ${{needs.clone-repo.outputs.repo-destination}}/kubernetes/explorer.yaml
-          docker-image: ${{ env.build_name }}:${{ needs.changes.output.explorer == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
+          docker-image: ${{ env.build_name }}:${{ env.build_name == 'true' && github.sha || join(needs.build-info.outputs.branch-name, '-latest') }}
           namespace: ${{ needs.build-info.outputs.namespace }}
           config-envs: POSTGRES_URL,SOCKET_URI,FIREHOSE_IDENTIFIER
 

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -33,7 +33,7 @@ jobs:
               - 'kubernetes/**'
       - name: Debug
         run: |
-          echo "${{ steps.filter.changed_files }"
+          echo "${{ steps.filter.changed_files }}"
 
   build-info:
     name: Get Build Info

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -31,6 +31,9 @@ jobs:
               - 'explorer/**'
             kubernetes:
               - 'kubernetes/**'
+      - name: Debug
+        run: |
+          echo "${{ steps.filter.changed_files }"
 
   build-info:
     name: Get Build Info

--- a/kubernetes/backend.yaml
+++ b/kubernetes/backend.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: boshi-backend
           image: ${IMAGE}
-          imagePullPolicy: IfNotPresent
+          imagePullPolicy: Always
           env:
             - name: PORT
               value: "80"

--- a/kubernetes/backend.yaml
+++ b/kubernetes/backend.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: boshi-backend
           image: ${IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: PORT
               value: "80"

--- a/kubernetes/explorer.yaml
+++ b/kubernetes/explorer.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: explorer
           image: ${IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           env:
             - name: POSTGRES_URL
               value: ${POSTGRES_URL}

--- a/kubernetes/frontend.yaml
+++ b/kubernetes/frontend.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: boshi-frontend
           image: ${IMAGE}
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 80
 ---

--- a/kubernetes/landing.yaml
+++ b/kubernetes/landing.yaml
@@ -17,7 +17,7 @@ spec:
       containers:
         - name: boshi-landing
           image: matthew10125/boshi-landing
-          imagePullPolicy: Always
+          imagePullPolicy: IfNotPresent
           ports:
             - containerPort: 3000
 ---


### PR DESCRIPTION
# Description

Previous conditions would not rollout updates if the respective Kubernetes files were changed. Furthermore, the docker-image given to the Kubernetes deployment action was the latest for the current branch, but if no image was built there would be an `ImagePullErr` because no image exists. Logic was added to build an image if the namespace does not exist. 

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)
