### PR TITLE
feat: add email code endpoints

### DIFF
--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -140,6 +140,7 @@ jobs:
         env:
           CLUSTER_ISSUER: ${{secrets.CERT_MANAGER_CLUSTER_ISSUER}}
           POSTGRES_URL: ${{secrets.POSTGRES_URL}}
+          REDIS_URL: ${{secrets.REDIS_URL}}
           SMTP_FROM: ${{secrets.SMTP_FROM}}
           SMTP_HOST: ${{secrets.SMTP_HOST}}
           SMTP_PORT: ${{secrets.SMTP_PORT}}
@@ -154,7 +155,7 @@ jobs:
           config-path: ${{ needs.clone-repo.outputs.repo-destination }}/kubernetes/backend.yaml
           docker-image: ${{ env.build_name }}:${{ env.build_docker == 'true' && github.sha || format('{0}-latest', needs.build-info.outputs.branch-name) }}
           namespace: ${{ needs.build-info.outputs.namespace }}
-          config-envs: CLUSTER_ISSUER,POSTGRES_URL,SMTP_FROM,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD
+          config-envs: CLUSTER_ISSUER,POSTGRES_URL,REDIS_URL,SMTP_FROM,SMTP_HOST,SMTP_PORT,SMTP_USERNAME,SMTP_PASSWORD
 
   build-and-deploy-landing:
     needs: [changes, build-info, clone-repo]

--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,6 +1,7 @@
 export PORT=8080
 export DOMAIN=boshi.deguzman.cloud
 export POSTGRES_URL=postgresql://admin:password@localhost:5432/boshi
+export REDIS_URL=redis://localhost:6379/0
 export SMTP_FROM=noreply@boshi.com
 export SMTP_HOST=smtp.host.com
 export SMTP_PORT=485

--- a/backend/Makefile
+++ b/backend/Makefile
@@ -20,6 +20,9 @@ build:
 	go build -o bin/boshi-backend cmd/main.go
 
 run:
+	@echo "Setting up services..."
+	docker compose up -d
+
 	@echo "Running the application..."
 	go run cmd/main.go
 
@@ -36,7 +39,14 @@ docker:
 	   if [[ subdomain == "main" ]]; then subdomain="boshi"; fi && \
 		docker build --build-arg DOMAIN=$${subdomain}.deguzman.cloud --platform $(PLATFORM) -t $(BUILD_NAME) .
 
+stop:
+	@echo "Stopping services"
+	docker compose down
+
 clean:
+	@echo "Cleaning up docker containers"
+	docker compose down --remove-orphans -v
+
 	@echo "Cleaning bin directory..."
 	rm bin/*
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,1 +1,25 @@
 # Boshi Backend
+
+## Setup
+
+To run the backend, ensure you have [Go 1.23](https://go.dev/dl/) installed and copy the `.env.example` file to `.env` and fill in the required environment variables.
+
+The backend requires a PostgreSQL database and Redis server. You can run the following command via Docker to start both services locally:
+
+```bash
+docker compose up -d
+```
+
+Adjust the the `docker-compose.yaml` file if you want to change the default ports or database name. Don't forget to change the `.env` file to reflect the changes.
+
+You can stop the services by running:
+
+```bash
+docker compose down
+```
+
+After setting up the docker services, run the following command to start the server:
+
+```bash
+make run
+```

--- a/backend/README.md
+++ b/backend/README.md
@@ -2,24 +2,37 @@
 
 ## Setup
 
-To run the backend, ensure you have [Go 1.23](https://go.dev/dl/) installed and copy the `.env.example` file to `.env` and fill in the required environment variables.
+To run the backend, ensure you have the following installed:
 
-The backend requires a PostgreSQL database and Redis server. You can run the following command via Docker to start both services locally:
+- [Go 1.23](https://go.dev/dl/)
+- [Docker](https://docs.docker.com/compose/install/)
 
-```bash
-docker compose up -d
-```
+Next, copy the `.env.example` file to `.env` and fill in the required environment variables.
 
-Adjust the the `docker-compose.yaml` file if you want to change the default ports or database name. Don't forget to change the `.env` file to reflect the changes.
-
-You can stop the services by running:
-
-```bash
-docker compose down
-```
-
-After setting up the docker services, run the following command to start the server:
+Then run the following command to start up the PostgreSQL and Redis instances and the server.
 
 ```bash
 make run
 ```
+
+The PostgreSQL and Redis instances are setup via the `docker-compose.yaml` file and can be adjusted to your liking. Be sure to update any necessary variables in `.env` to reflect your changes.
+
+## Stop
+
+To stop the services, run
+
+```bash
+make stop
+```
+
+This stops the services started in the setup step.
+
+## Restart
+
+If you have made any changes to `schema.sql` and would like them to be reflected in the PostgreSQL instance, you may wipe the instances clean with
+
+```bash
+make clean
+```
+
+which removes any associated volumes with the database instances (and cleans the `/bin` folder). Running `make run` again will start the PostgreSQL instance with the new schema.

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -65,6 +65,14 @@ func main() {
 		),
 	)
 
+	mux.HandleFunc("POST /email/verify",
+		middleware.Chain(
+			endpoints.VerifyEmailCode,
+			middleware.AddCors(),
+			middleware.LogRequest(),
+		),
+	)
+
 	/* Setup server*/
 	port := os.Getenv("PORT")
 	if port == "" {

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -1,9 +1,11 @@
 package main
 
 import (
+	"boshi-backend/internal/database"
 	"boshi-backend/internal/endpoints"
 	"boshi-backend/internal/logger"
 	"boshi-backend/internal/middleware"
+	"boshi-backend/internal/redis"
 	"fmt"
 	"net/http"
 	"os"
@@ -11,8 +13,14 @@ import (
 
 var log = logger.GetLogger()
 
+func cleanup() {
+	database.CloseDb()
+	redis.CloseRedis()
+}
+
 func main() {
 	log.Info("Starting server...")
+	defer cleanup()
 
 	/* Setup routes */
 	mux := http.NewServeMux()
@@ -44,6 +52,14 @@ func main() {
 	mux.HandleFunc("POST /email-list",
 		middleware.Chain(
 			endpoints.HandleAddEmailToEmailList,
+			middleware.AddCors(),
+			middleware.LogRequest(),
+		),
+	)
+
+	mux.HandleFunc("POST /email/code",
+		middleware.Chain(
+			endpoints.CreateEmailVerificationCode,
 			middleware.AddCors(),
 			middleware.LogRequest(),
 		),

--- a/backend/cmd/main.go
+++ b/backend/cmd/main.go
@@ -51,7 +51,7 @@ func main() {
 
 	mux.HandleFunc("POST /email-list",
 		middleware.Chain(
-			endpoints.HandleAddEmailToEmailList,
+			endpoints.AddEmailToEmailList,
 			middleware.AddCors(),
 			middleware.LogRequest(),
 		),

--- a/backend/docker-compose.yaml
+++ b/backend/docker-compose.yaml
@@ -1,6 +1,6 @@
 services:
   postgres:
-    image: postgres:latest
+    image: postgres:17
     container_name: boshi-postgres
     restart: always
     environment:
@@ -13,6 +13,17 @@ services:
       - postgres_data:/var/lib/postgresql/data
       - ./schema.sql:/docker-entrypoint-initdb.d/init.sql:ro
 
+  redis:
+    image: redis:7.4.1
+    container_name: boshi-redis
+    restart: always
+    ports:
+      - "6379:6379"
+    volumes:
+      - redis_data:/data
+
 volumes:
   postgres_data:
+    driver: local
+  redis_data:
     driver: local

--- a/backend/go.mod
+++ b/backend/go.mod
@@ -3,10 +3,13 @@ module boshi-backend
 go 1.23.0
 
 require (
+	github.com/cespare/xxhash/v2 v2.2.0 // indirect
+	github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/pgx/v5 v5.7.4 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/redis/go-redis/v9 v9.7.3 // indirect
 	golang.org/x/crypto v0.31.0 // indirect
 	golang.org/x/sync v0.10.0 // indirect
 	golang.org/x/text v0.21.0 // indirect

--- a/backend/go.sum
+++ b/backend/go.sum
@@ -1,4 +1,8 @@
+github.com/cespare/xxhash/v2 v2.2.0 h1:DC2CZ1Ep5Y4k3ZQ899DldepgrayRUGE6BBZ/cd9Cj44=
+github.com/cespare/xxhash/v2 v2.2.0/go.mod h1:VGX0DQ3Q6kWi7AoAeZDth3/j3BFtOZR5XLFGgcrjCOs=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f h1:lO4WD4F/rVNCu3HqELle0jiPLLBs70cWOduZpkS1E78=
+github.com/dgryski/go-rendezvous v0.0.0-20200823014737-9f7001d12a5f/go.mod h1:cuUVRXasLTGF7a8hSLbxyZXjz+1KgoB3wDUb6vlszIc=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -8,6 +12,8 @@ github.com/jackc/pgx/v5 v5.7.4/go.mod h1:ncY89UGWxg82EykZUwSpUKEfccBGGYq1xjrOpsb
 github.com/jackc/puddle/v2 v2.2.2 h1:PR8nw+E/1w0GLuRFSmiioY6UooMp6KJv0/61nB7icHo=
 github.com/jackc/puddle/v2 v2.2.2/go.mod h1:vriiEXHvEE654aYKXXjOvZM39qJ0q+azkZFrfEOc3H4=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
+github.com/redis/go-redis/v9 v9.7.3 h1:YpPyAayJV+XErNsatSElgRZZVCwXX9QzkKYNvO7x0wM=
+github.com/redis/go-redis/v9 v9.7.3/go.mod h1:bGUrSggJ9X9GUmZpZNEOQKaANxSGgOEBRltRTZHSvrA=
 github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+wExME=
 github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UVUgZn+9EI=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=

--- a/backend/internal/database/postgres.go
+++ b/backend/internal/database/postgres.go
@@ -21,7 +21,7 @@ func init() {
 	}
 }
 
-// Retrieves a singleton instance of the Redis client.
+// Retrieves a singleton instance of the PostgreSQL client.
 func GetDb(ctx context.Context) *pgxpool.Pool {
 	once.Do(func() {
 		var err error
@@ -33,7 +33,7 @@ func GetDb(ctx context.Context) *pgxpool.Pool {
 	return pool
 }
 
-// Closes redis connection. Should only be called when the
+// Closes connection. Should only be called when the
 // application is shutting down.
 func CloseDb() {
 	if pool != nil {

--- a/backend/internal/database/postgres.go
+++ b/backend/internal/database/postgres.go
@@ -21,6 +21,7 @@ func init() {
 	}
 }
 
+// Retrieves a singleton instance of the Redis client.
 func GetDb(ctx context.Context) *pgxpool.Pool {
 	once.Do(func() {
 		var err error
@@ -32,6 +33,8 @@ func GetDb(ctx context.Context) *pgxpool.Pool {
 	return pool
 }
 
+// Closes redis connection. Should only be called when the
+// application is shutting down.
 func CloseDb() {
 	if pool != nil {
 		pool.Close()

--- a/backend/internal/database/postgres.go
+++ b/backend/internal/database/postgres.go
@@ -4,12 +4,15 @@ import (
 	"boshi-backend/internal/logger"
 	"context"
 	"os"
+	"sync"
 
 	"github.com/jackc/pgx/v5/pgxpool"
 )
 
 var log = logger.GetLogger()
+var once sync.Once
 var pgUrl string
+var pool *pgxpool.Pool
 
 func init() {
 	pgUrl = os.Getenv("POSTGRES_URL")
@@ -18,11 +21,19 @@ func init() {
 	}
 }
 
-func Connect(ctx context.Context) *pgxpool.Pool {
-	pool, err := pgxpool.New(ctx, pgUrl)
-	if err != nil {
-		panic(err)
-	}
-	log.Debug("Successfully connected to DB")
+func GetDb(ctx context.Context) *pgxpool.Pool {
+	once.Do(func() {
+		var err error
+		pool, err = pgxpool.New(ctx, pgUrl)
+		if err != nil {
+			panic(err)
+		}
+	})
 	return pool
+}
+
+func CloseDb() {
+	if pool != nil {
+		pool.Close()
+	}
 }

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -1,8 +1,10 @@
 package email
 
 import (
+	"crypto/rand"
 	"errors"
 	"fmt"
+	"math/big"
 	"net/smtp"
 	"os"
 )
@@ -10,15 +12,30 @@ import (
 const welcomeSubject string = "Welcome to Boshi"
 const welcomeBody string = "Thank you for signing up for the Boshi mail list! We are excited that you've decided to join us on our journey. Updates are coming soon."
 
+var host string
+var port string
+var username string
+var password string
+var boshiSender string
+
+var ErrMissingEnvVars = errors.New("Missing SMTP environment variables")
+
+func init() {
+	host, port, username, password, boshiSender = os.Getenv("SMTP_HOST"), os.Getenv("SMTP_PORT"), os.Getenv("SMTP_USERNAME"), os.Getenv("SMTP_PASSWORD"), os.Getenv("SMTP_FROM")
+}
+
+func validateVariables() bool {
+	return host == "" || port == "" || username == "" || password == ""
+}
+
 func formatMessage(sender, recipient, subject, body string) []byte {
 	return []byte(fmt.Sprintf("From: %s\r\nTo: %s\r\nSubject: %s\r\n\r\n%s", sender, recipient, subject, body))
 }
 
-func SendEmailListWelcome(recipient string) error {
-	/* Send email */
-	host, port, username, password, boshiSender := os.Getenv("SMTP_HOST"), os.Getenv("SMTP_PORT"), os.Getenv("SMTP_USERNAME"), os.Getenv("SMTP_PASSWORD"), os.Getenv("SMTP_FROM")
-	if host == "" || port == "" || username == "" || password == "" {
-		return errors.New("Missing SMTP environment variables")
+// Send an email to the recipient with the given subject and body
+func SendEmail(recipient string, subject string, body string) error {
+	if validateVariables() {
+		return ErrMissingEnvVars
 	}
 
 	err := smtp.SendMail(
@@ -26,10 +43,23 @@ func SendEmailListWelcome(recipient string) error {
 		smtp.PlainAuth("", username, password, host),
 		boshiSender,
 		[]string{recipient},
-		formatMessage(boshiSender, recipient, welcomeSubject, welcomeBody),
+		formatMessage(boshiSender, recipient, subject, body),
 	)
 	if err != nil {
 		return err
 	}
 	return nil
+
+}
+
+// Generate an 8 digit numeric verification code
+func GenerateVerificationCode() (string, error) {
+	var maxRand *big.Int = big.NewInt(89_999_999)
+	var offset *big.Int = big.NewInt(10_000_000)
+	code, err := rand.Int(rand.Reader, maxRand)
+	if err != nil {
+		return "", err
+	}
+	code = code.Add(code, offset)
+	return code.String(), nil
 }

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -9,23 +9,16 @@ import (
 	"os"
 )
 
-const welcomeSubject string = "Welcome to Boshi"
-const welcomeBody string = "Thank you for signing up for the Boshi mail list! We are excited that you've decided to join us on our journey. Updates are coming soon."
-
-var host string
-var port string
-var username string
-var password string
-var boshiSender string
+var host string = os.Getenv("SMTP_HOST")
+var port string = os.Getenv("SMTP_PORT")
+var username string = os.Getenv("SMTP_USERNAME")
+var password string = os.Getenv("SMTP_PASSWORD")
+var boshiSender string = os.Getenv("SMTP_FROM")
 
 var ErrMissingEnvVars = errors.New("Missing SMTP environment variables")
 
-func init() {
-	host, port, username, password, boshiSender = os.Getenv("SMTP_HOST"), os.Getenv("SMTP_PORT"), os.Getenv("SMTP_USERNAME"), os.Getenv("SMTP_PASSWORD"), os.Getenv("SMTP_FROM")
-}
-
 func validateVariables() bool {
-	return host == "" || port == "" || username == "" || password == ""
+	return host == "" || port == "" || username == "" || password == "" || boshiSender == ""
 }
 
 func formatMessage(sender, recipient, subject, body string) []byte {

--- a/backend/internal/email/email.go
+++ b/backend/internal/email/email.go
@@ -4,10 +4,12 @@ import (
 	"crypto/rand"
 	"errors"
 	"fmt"
-	"math/big"
 	"net/smtp"
 	"os"
 )
+
+const verificationCodeSet = "ABCDEFGHJKMNOPQRSTUVWXYZ23456789" // Similar characters removed
+const verificationCodeLength = 6
 
 var host string = os.Getenv("SMTP_HOST")
 var port string = os.Getenv("SMTP_PORT")
@@ -45,14 +47,15 @@ func SendEmail(recipient string, subject string, body string) error {
 
 }
 
-// Generate an 8 digit numeric verification code
+// Generate an alphanumeric verification code
 func GenerateVerificationCode() (string, error) {
-	var maxRand *big.Int = big.NewInt(89_999_999)
-	var offset *big.Int = big.NewInt(10_000_000)
-	code, err := rand.Int(rand.Reader, maxRand)
+	code := make([]byte, verificationCodeLength)
+	_, err := rand.Read(code)
 	if err != nil {
 		return "", err
 	}
-	code = code.Add(code, offset)
-	return code.String(), nil
+	for i := range code {
+		code[i] = verificationCodeSet[code[i]%byte(len(verificationCodeSet))]
+	}
+	return string(code), nil
 }

--- a/backend/internal/endpoints/email.go
+++ b/backend/internal/endpoints/email.go
@@ -149,6 +149,7 @@ func CreateEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// Commit transaction
 	log.DebugContext(r.Context(), "Committing transaction")
 	if err := tx.Commit(ctx); err != nil {
 		log.ErrorContext(r.Context(), "Failed to commit transaction", slog.Any("error", err))
@@ -191,17 +192,17 @@ func CreateEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Send email
-	// log.DebugContext(r.Context(), "Sending email")
-	// err = email.SendEmail(
-	// 	payload.Email,
-	// 	"Boshi Email Verification Code",
-	// 	fmt.Sprintf("Your Boshi verification code is: %s", code),
-	// )
-	// if err != nil {
-	// 	log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
-	// 	http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-	// 	return
-	// }
+	log.DebugContext(r.Context(), "Sending email")
+	err = email.SendEmail(
+		payload.Email,
+		"Boshi Verification Code",
+		fmt.Sprintf("Your Boshi verification code is: %s", code),
+	)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 }
 
 func VerifyEmailCode(w http.ResponseWriter, r *http.Request) {

--- a/backend/internal/endpoints/email.go
+++ b/backend/internal/endpoints/email.go
@@ -263,6 +263,8 @@ func VerifyEmailCode(w http.ResponseWriter, r *http.Request) {
 			"Received unhandled status",
 			slog.String("status", string(verificationStatus)),
 		)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
 	}
 
 	// Get code from redis

--- a/backend/internal/endpoints/email.go
+++ b/backend/internal/endpoints/email.go
@@ -1,0 +1,283 @@
+package endpoints
+
+import (
+	"boshi-backend/internal/database"
+	"boshi-backend/internal/email"
+	boshiRedis "boshi-backend/internal/redis"
+	"boshi-backend/internal/sqlc"
+	"context"
+	"crypto/subtle"
+	"errors"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/mail"
+	"strings"
+	"time"
+
+	"github.com/jackc/pgx/v5"
+	"github.com/jackc/pgx/v5/pgconn"
+	"github.com/redis/go-redis/v9"
+)
+
+const EmailVerficationCodeKey = "email-verification-code"
+
+var EmailVerificationCodeTTL = time.Duration(10) * time.Minute
+var pgError *pgconn.PgError
+
+func generateVerificationRedisKey(email string) string {
+	return fmt.Sprintf("%s:%s", EmailVerficationCodeKey, email)
+}
+
+func AddEmailToEmailList(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	var db = database.GetDb(ctx)
+	var sqlcDb = sqlc.New(db)
+
+	// Decode Payload
+	log.DebugContext(r.Context(), "Decoding payload")
+	var payload emailListPayload
+	err := decodeJson(&payload, r)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
+		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
+		return
+	}
+
+	// Validate email
+	log.DebugContext(r.Context(), "Validating email")
+	if _, err := mail.ParseAddress(payload.Email); err != nil {
+		log.ErrorContext(r.Context(), "Invalid email address", slog.Any("error", err))
+		http.Error(w, "Invalid email address", http.StatusBadRequest)
+		return
+	}
+
+	// Insert email into database
+	log.DebugContext(r.Context(), "Inserting email into database")
+	if err := sqlcDb.AddToMailList(ctx, payload.Email); err != nil {
+		if pgError, ok := err.(*pgconn.PgError); ok && pgError.Code == "23505" {
+			// Check for unique constraint violation
+			log.DebugContext(r.Context(), "Email already exists in database")
+			http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
+			return
+		}
+		log.ErrorContext(r.Context(), "Failed to insert email into database", slog.Any("error", err))
+		http.Error(w, "Failed to insert email into database", http.StatusInternalServerError)
+		return
+	}
+
+	// Send email
+	log.InfoContext(r.Context(), "Sending email")
+	err = email.SendEmail(
+		payload.Email,
+		"Welcome to Boshi",
+		"Thank you for signing up for the Boshi mail list! We are excited that you've decided to join us on our journey. Updates are coming soon.",
+	)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
+		http.Error(w, "Failed to send email", http.StatusInternalServerError)
+		return
+	}
+}
+
+func CreateEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	var db = database.GetDb(ctx)
+	var sqlcDb = sqlc.New(db)
+
+	// Decode Payload
+	log.DebugContext(r.Context(), "Decoding payload")
+	var payload emailListPayload
+	err := decodeJson(&payload, r)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
+		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
+		return
+	}
+
+	// Validate email
+	log.DebugContext(r.Context(), "Validating email")
+	if _, err := mail.ParseAddress(payload.Email); err != nil {
+		log.ErrorContext(r.Context(), "Invalid email address", slog.Any("error", err))
+		http.Error(w, "Invalid email address", http.StatusBadRequest)
+		return
+	}
+	if !strings.HasSuffix(payload.Email, ".edu") {
+		log.ErrorContext(r.Context(), "Email address must end with .edu", slog.String("email", payload.Email))
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	// Add email to database and check if it is already verified
+	log.DebugContext(r.Context(), "Begin database transaction")
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to begin transaction", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback(ctx)
+	qtx := sqlcDb.WithTx(tx)
+
+	// Insert email into database
+	log.DebugContext(r.Context(), "Inserting email into database")
+	txR, err := qtx.AddUnverifiedEmail(ctx, payload.Email)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to insert email into database", slog.Any("error", err))
+		http.Error(w, "Failed to insert email into database", http.StatusInternalServerError)
+		return
+	}
+
+	// Check if email is already verified
+	log.DebugContext(r.Context(), "Check if email is already verified")
+	if !txR.VerifiedAt.Time.IsZero() {
+		log.ErrorContext(r.Context(), "Email already verified", slog.String("email", payload.Email))
+		http.Error(w, "Email already verified", http.StatusConflict)
+		return
+	}
+
+	log.DebugContext(r.Context(), "Committing transaction")
+	if err := tx.Commit(ctx); err != nil {
+		log.ErrorContext(r.Context(), "Failed to commit transaction", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Generate random code
+	log.DebugContext(r.Context(), "Generating code")
+	code, err := email.GenerateVerificationCode()
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to generate verification code", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Insert code into redis
+	log.DebugContext(r.Context(), "Inserting code into redis")
+	key := generateVerificationRedisKey(payload.Email)
+	// key := "example"
+	log.DebugContext(r.Context(), "Key", slog.String("key", key))
+	var redisClient = boshiRedis.GetClient()
+
+	// Set the key if it is not already set
+	ok, err := redisClient.SetNX(
+		ctx,
+		key,
+		code,
+		EmailVerificationCodeTTL,
+	).Result()
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to set verification code in redis", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		log.ErrorContext(r.Context(), "Key already exists, not setting.", slog.String("key", key))
+		http.Error(w, "Verification code already set", http.StatusConflict)
+		return
+	}
+
+	// Send email
+	log.DebugContext(r.Context(), "Sending email")
+	err = email.SendEmail(
+		payload.Email,
+		"Boshi Email Verification Code",
+		fmt.Sprintf("Your Boshi verification code is: %s", code),
+	)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+}
+
+func VerifyEmailCode(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+	var db = database.GetDb(ctx)
+	var sqlcDb = sqlc.New(db)
+
+	// Decode Payload
+	log.DebugContext(r.Context(), "Decoding payload")
+	var payload verifyEmailVerificationCodePayload
+	err := decodeJson(&payload, r)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
+		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
+		return
+	}
+
+	// Begin postgres transaction to make update process "transactional"
+	// The verification status will *only* be updated if the redis transaction
+	// is also successful. Otherwise, the update will be rolled back.
+	log.InfoContext(r.Context(), "Beginning database transaction")
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to begin transaction", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback(ctx)
+	qtx := sqlcDb.WithTx(tx)
+
+	log.DebugContext(r.Context(), "Updating verification status")
+	_, err = qtx.VerifyEmail(ctx, payload.Email)
+	if errors.Is(err, pgx.ErrNoRows) {
+		log.ErrorContext(r.Context(), "Email not found", slog.String("email", payload.Email))
+		http.Error(w, "Email not found", http.StatusNotFound)
+		return
+	} else if err != nil {
+		log.ErrorContext(
+			r.Context(),
+			"Failed to update verification status",
+			slog.Any("error", err),
+			slog.String("email", payload.Email),
+		)
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Get code from redis
+	key := generateVerificationRedisKey(payload.Email)
+	log.DebugContext(r.Context(), "Retrieving key from redis", slog.String("key", key))
+	redisClient := boshiRedis.GetClient()
+	code, err := redisClient.Get(ctx, key).Result()
+	if errors.Is(err, redis.Nil) {
+		log.ErrorContext(r.Context(), "Key not found", slog.String("key", key))
+		http.Error(w, "Invalid Key", http.StatusNotFound)
+		return
+	} else if err != nil {
+		log.ErrorContext(r.Context(), "Failed to GET key", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Compare codes
+	log.DebugContext(r.Context(), "Comparing codes")
+	if subtle.ConstantTimeCompare([]byte(code), []byte(payload.Code)) != 1 {
+		log.ErrorContext(r.Context(), "Codes do not match")
+		http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
+		return
+	}
+
+	// Delete key
+	log.DebugContext(r.Context(), "Removing key from redis")
+	err = redisClient.Del(ctx, key).Err()
+	if errors.Is(err, redis.Nil) {
+		log.ErrorContext(r.Context(), "Key not found", slog.String("key", key))
+		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
+		return
+	} else if err != nil {
+		log.ErrorContext(r.Context(), "Failed to DEL key", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	log.DebugContext(r.Context(), "Successfully removed key")
+
+	// Commit transaction - this is not fully transaction, but good enough
+	log.DebugContext(r.Context(), "Committing transaction")
+	if err := tx.Commit(ctx); err != nil {
+		log.ErrorContext(r.Context(), "Failed to commit db transaction", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+}

--- a/backend/internal/endpoints/endpoints.go
+++ b/backend/internal/endpoints/endpoints.go
@@ -1,42 +1,24 @@
 package endpoints
 
 import (
-	"boshi-backend/internal/database"
-	"boshi-backend/internal/email"
 	"boshi-backend/internal/logger"
-	boshiRedis "boshi-backend/internal/redis"
-	"boshi-backend/internal/sqlc"
-	"context"
-	"crypto/subtle"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"log/slog"
 	"net/http"
-	"net/mail"
 	"os"
-	"strings"
-
-	"github.com/jackc/pgx/v5"
-	"github.com/jackc/pgx/v5/pgconn"
-	"github.com/redis/go-redis/v9"
 )
 
 var log = logger.GetLogger()
-var db = database.GetDb(context.Background())
-var sqlcDb = sqlc.New(db)
-
-var pgError *pgconn.PgError
-
-var ErrVerificationCodeExists = fmt.Errorf("verification code already exists")
-
-func generateVerificationRedisKey(email string) string {
-	return fmt.Sprintf("%s:%s", boshiRedis.EmailVerficationCodeKey, email)
-}
 
 // Returns client-metadata.json for initiating OAuth2 authorization code flow
 func ServeOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 	domain := os.Getenv("DOMAIN")
+	if domain == "" {
+		log.ErrorContext(r.Context(), "DOMAIN not set")
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
 
 	log.DebugContext(r.Context(), "Encoding client metadata")
 	w.Header().Set("Content-Type", "application/json")
@@ -56,251 +38,5 @@ func ServeOAuthMetadata(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		log.ErrorContext(r.Context(), "Failed to encode response", slog.Any("error", err))
 		http.Error(w, "Failed to encode response", http.StatusInternalServerError)
-	}
-}
-
-func HandleAddEmailToEmailList(w http.ResponseWriter, r *http.Request) {
-	// Decode Payload
-	log.DebugContext(r.Context(), "Decoding payload")
-	var payload emailListPayload
-	err := decodeJson(&payload, r)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
-		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
-		return
-	}
-
-	// Validate email
-	log.DebugContext(r.Context(), "Validating email")
-	if _, err := mail.ParseAddress(payload.Email); err != nil {
-		log.ErrorContext(r.Context(), "Invalid email address", slog.Any("error", err))
-		http.Error(w, "Invalid email address", http.StatusBadRequest)
-		return
-	}
-
-	// Insert email into database
-	log.DebugContext(r.Context(), "Inserting email into database")
-	if err := sqlcDb.AddToMailList(r.Context(), payload.Email); err != nil {
-		if pgError, ok := err.(*pgconn.PgError); ok && pgError.Code == "23505" {
-			// Check for unique constraint violation
-			log.DebugContext(r.Context(), "Email already exists in database")
-			http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
-			return
-		}
-		log.ErrorContext(r.Context(), "Failed to insert email into database", slog.Any("error", err))
-		http.Error(w, "Failed to insert email into database", http.StatusInternalServerError)
-		return
-	}
-
-	// Send email
-	log.InfoContext(r.Context(), "Sending email")
-	err = email.SendEmail(
-		payload.Email,
-		"Welcome to Boshi",
-		"Thank you for signing up for the Boshi mail list! We are excited that you've decided to join us on our journey. Updates are coming soon.",
-	)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
-		http.Error(w, "Failed to send email", http.StatusInternalServerError)
-		return
-	}
-}
-
-func CreateEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
-	ctx := context.Background()
-
-	// Decode Payload
-	log.DebugContext(r.Context(), "Decoding payload")
-	var payload emailListPayload
-	err := decodeJson(&payload, r)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
-		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
-		return
-	}
-
-	// Validate email
-	log.DebugContext(r.Context(), "Validating email")
-	if _, err := mail.ParseAddress(payload.Email); err != nil {
-		log.ErrorContext(r.Context(), "Invalid email address", slog.Any("error", err))
-		http.Error(w, "Invalid email address", http.StatusBadRequest)
-		return
-	}
-	if !strings.HasSuffix(payload.Email, ".edu") {
-		log.ErrorContext(r.Context(), "Email address must end with .edu", slog.String("email", payload.Email))
-		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
-		return
-	}
-
-	// Add email to database and check if it is already verified
-	log.DebugContext(r.Context(), "Begin database transaction")
-	tx, err := db.Begin(ctx)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to begin transaction", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-	defer tx.Rollback(ctx)
-	qtx := sqlcDb.WithTx(tx)
-
-	// Insert email into database
-	log.DebugContext(r.Context(), "Inserting email into database")
-	txR, err := qtx.AddUnverifiedEmail(ctx, payload.Email)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to insert email into database", slog.Any("error", err))
-		http.Error(w, "Failed to insert email into database", http.StatusInternalServerError)
-		return
-	}
-
-	// Check if email is already verified
-	log.DebugContext(r.Context(), "Check if email is already verified")
-	if !txR.VerifiedAt.Time.IsZero() {
-		log.ErrorContext(r.Context(), "Email already verified", slog.String("email", payload.Email))
-		http.Error(w, "Email already verified", http.StatusConflict)
-		return
-	}
-
-	log.DebugContext(r.Context(), "Committing transaction")
-	if err := tx.Commit(ctx); err != nil {
-		log.ErrorContext(r.Context(), "Failed to commit transaction", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
-	// Generate random code
-	log.DebugContext(r.Context(), "Generating code")
-	code, err := email.GenerateVerificationCode()
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to generate verification code", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
-	// Insert code into redis
-	log.DebugContext(r.Context(), "Inserting code into redis")
-	key := generateVerificationRedisKey(payload.Email)
-	// key := "example"
-	log.DebugContext(r.Context(), "Key", slog.String("key", key))
-	var redisClient = boshiRedis.GetClient()
-
-	// Set the key if it is not already set
-	ok, err := redisClient.SetNX(
-		ctx,
-		key,
-		code,
-		boshiRedis.EmailVerificationCodeTTL,
-	).Result()
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to set verification code in redis", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-	if !ok {
-		log.ErrorContext(r.Context(), "Key already exists, not setting.", slog.String("key", key))
-		http.Error(w, "Verification code already set", http.StatusConflict)
-		return
-	}
-
-	// Send email
-	log.DebugContext(r.Context(), "Sending email")
-	err = email.SendEmail(
-		payload.Email,
-		"Boshi Email Verification Code",
-		fmt.Sprintf("Your Boshi verification code is: %s", code),
-	)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-}
-
-func VerifyEmailCode(w http.ResponseWriter, r *http.Request) {
-	// Decode payload
-	ctx := context.Background()
-
-	// Decode Payload
-	log.DebugContext(r.Context(), "Decoding payload")
-	var payload verifyEmailVerificationCodePayload
-	err := decodeJson(&payload, r)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
-		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
-		return
-	}
-
-	// Begin postgres transaction to make update process "transactional"
-	// The verification status will *only* be updated if the redis transaction
-	// is also successful. Otherwise, the update will be rolled back.
-	log.InfoContext(r.Context(), "Beginning database transaction")
-	tx, err := db.Begin(ctx)
-	if err != nil {
-		log.ErrorContext(r.Context(), "Failed to begin transaction", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-	defer tx.Rollback(ctx)
-	qtx := sqlcDb.WithTx(tx)
-
-	log.DebugContext(r.Context(), "Updating verification status")
-	_, err = qtx.VerifyEmail(ctx, payload.Email)
-	if errors.Is(err, pgx.ErrNoRows) {
-		log.ErrorContext(r.Context(), "Email not found", slog.String("email", payload.Email))
-		http.Error(w, "Email not found", http.StatusNotFound)
-		return
-	} else if err != nil {
-		log.ErrorContext(
-			r.Context(),
-			"Failed to update verification status",
-			slog.Any("error", err),
-			slog.String("email", payload.Email),
-		)
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
-	// Get code from redis
-	key := generateVerificationRedisKey(payload.Email)
-	log.DebugContext(r.Context(), "Retrieving key from redis", slog.String("key", key))
-	redisClient := boshiRedis.GetClient()
-	code, err := redisClient.Get(ctx, key).Result()
-	if errors.Is(err, redis.Nil) {
-		log.ErrorContext(r.Context(), "Key not found", slog.String("key", key))
-		http.Error(w, "Invalid Key", http.StatusNotFound)
-		return
-	} else if err != nil {
-		log.ErrorContext(r.Context(), "Failed to GET key", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-
-	// Compare codes
-	log.DebugContext(r.Context(), "Comparing codes")
-	if subtle.ConstantTimeCompare([]byte(code), []byte(payload.Code)) != 1 {
-		log.ErrorContext(r.Context(), "Codes do not match")
-		http.Error(w, http.StatusText(http.StatusConflict), http.StatusConflict)
-		return
-	}
-
-	// Delete key
-	log.DebugContext(r.Context(), "Removing key from redis")
-	err = redisClient.Del(ctx, key).Err()
-	if errors.Is(err, redis.Nil) {
-		log.ErrorContext(r.Context(), "Key not found", slog.String("key", key))
-		http.Error(w, http.StatusText(http.StatusNotFound), http.StatusNotFound)
-		return
-	} else if err != nil {
-		log.ErrorContext(r.Context(), "Failed to DEL key", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
-	}
-	log.DebugContext(r.Context(), "Successfully removed key")
-
-	// Commit transaction - this is not fully transaction, but good enough
-	log.DebugContext(r.Context(), "Committing transaction")
-	if err := tx.Commit(ctx); err != nil {
-		log.ErrorContext(r.Context(), "Failed to commit db transaction", slog.Any("error", err))
-		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
-		return
 	}
 }

--- a/backend/internal/endpoints/endpoints.go
+++ b/backend/internal/endpoints/endpoints.go
@@ -4,6 +4,7 @@ import (
 	"boshi-backend/internal/database"
 	"boshi-backend/internal/email"
 	"boshi-backend/internal/logger"
+	boshiRedis "boshi-backend/internal/redis"
 	"boshi-backend/internal/sqlc"
 	"context"
 	"encoding/json"
@@ -12,15 +13,18 @@ import (
 	"net/http"
 	"net/mail"
 	"os"
+	"strings"
 
 	"github.com/jackc/pgx/v5/pgconn"
 )
 
 var log = logger.GetLogger()
-var db = database.Connect(context.Background())
+var db = database.GetDb(context.Background())
 var sqlcDb = sqlc.New(db)
 
 var pgError *pgconn.PgError
+
+var ErrVerificationCodeExists = fmt.Errorf("verification code already exists")
 
 // Returns client-metadata.json for initiating OAuth2 authorization code flow
 func ServeOAuthMetadata(w http.ResponseWriter, r *http.Request) {
@@ -68,7 +72,7 @@ func HandleAddEmailToEmailList(w http.ResponseWriter, r *http.Request) {
 
 	// Insert email into database
 	log.DebugContext(r.Context(), "Inserting email into database")
-	if err := sqlcDb.InsertEmail(r.Context(), payload.Email); err != nil {
+	if err := sqlcDb.AddToMailList(r.Context(), payload.Email); err != nil {
 		if pgError, ok := err.(*pgconn.PgError); ok && pgError.Code == "23505" {
 			// Check for unique constraint violation
 			log.DebugContext(r.Context(), "Email already exists in database")
@@ -82,9 +86,124 @@ func HandleAddEmailToEmailList(w http.ResponseWriter, r *http.Request) {
 
 	// Send email
 	log.InfoContext(r.Context(), "Sending email")
-	if err := email.SendEmailListWelcome(payload.Email); err != nil {
+	err = email.SendEmail(
+		payload.Email,
+		"Welcome to Boshi",
+		"Thank you for signing up for the Boshi mail list! We are excited that you've decided to join us on our journey. Updates are coming soon.",
+	)
+	if err != nil {
 		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
 		http.Error(w, "Failed to send email", http.StatusInternalServerError)
+		return
+	}
+}
+
+func CreateEmailVerificationCode(w http.ResponseWriter, r *http.Request) {
+	ctx := context.Background()
+
+	// Decode Payload
+	log.DebugContext(r.Context(), "Decoding payload")
+	var payload emailListPayload
+	err := decodeJson(&payload, r)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to decode payload", slog.Any("error", err))
+		http.Error(w, "Failed to decode payload", http.StatusBadRequest)
+		return
+	}
+
+	// Validate email
+	log.DebugContext(r.Context(), "Validating email")
+	if _, err := mail.ParseAddress(payload.Email); err != nil {
+		log.ErrorContext(r.Context(), "Invalid email address", slog.Any("error", err))
+		http.Error(w, "Invalid email address", http.StatusBadRequest)
+		return
+	}
+	if !strings.HasSuffix(payload.Email, ".edu") {
+		log.ErrorContext(r.Context(), "Email address must end with .edu", slog.String("email", payload.Email))
+		http.Error(w, http.StatusText(http.StatusBadRequest), http.StatusBadRequest)
+		return
+	}
+
+	// Add email to database and check if it is already verified
+	log.DebugContext(r.Context(), "Begin database transaction")
+	db := database.GetDb(ctx)
+	tx, err := db.Begin(ctx)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to begin transaction", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	defer tx.Rollback(ctx)
+	qtx := sqlcDb.WithTx(tx)
+
+	// Insert email into database
+	log.DebugContext(r.Context(), "Inserting email into database")
+	txR, err := qtx.AddUnverifiedEmail(ctx, payload.Email)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to insert email into database", slog.Any("error", err))
+		http.Error(w, "Failed to insert email into database", http.StatusInternalServerError)
+		return
+	}
+
+	// Check if email is already verified
+	log.DebugContext(r.Context(), "Check if email is already verified")
+	if !txR.VerifiedAt.Time.IsZero() {
+		log.ErrorContext(r.Context(), "Email already verified", slog.String("email", payload.Email))
+		http.Error(w, "Email already verified", http.StatusConflict)
+		return
+	}
+
+	log.DebugContext(r.Context(), "Committing transaction")
+	if err := tx.Commit(ctx); err != nil {
+		log.ErrorContext(r.Context(), "Failed to commit transaction", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Generate random code
+	log.DebugContext(r.Context(), "Generating code")
+	code, err := email.GenerateVerificationCode()
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to generate verification code", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+
+	// Insert code into redis
+	log.DebugContext(r.Context(), "Inserting code into redis")
+	key := fmt.Sprintf("%s:%s", boshiRedis.EmailVerficationCodeKey, payload.Email)
+	// key := "example"
+	log.DebugContext(r.Context(), "Key", slog.String("key", key))
+	var redisClient = boshiRedis.GetClient()
+
+	// Set the key if it is not already set
+	ok, err := redisClient.SetNX(
+		ctx,
+		key,
+		code,
+		boshiRedis.EmailVerificationCodeTTL,
+	).Result()
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to set verification code in redis", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		log.ErrorContext(r.Context(), "Key already exists, not setting.", slog.String("key", key))
+		http.Error(w, "Verification code already set", http.StatusConflict)
+		return
+	}
+
+	// // Send email
+	log.DebugContext(r.Context(), "Sending email")
+	err = email.SendEmail(
+		payload.Email,
+		"Boshi Email Verification Code",
+		fmt.Sprintf("Your Boshi verification code is: %s", code),
+	)
+	if err != nil {
+		log.ErrorContext(r.Context(), "Failed to send email", slog.Any("error", err))
+		http.Error(w, http.StatusText(http.StatusInternalServerError), http.StatusInternalServerError)
 		return
 	}
 }

--- a/backend/internal/endpoints/payloads.go
+++ b/backend/internal/endpoints/payloads.go
@@ -20,3 +20,8 @@ type emailListPayload struct {
 type createEmailVerificationCodePayload struct {
 	Email string `json:"email"`
 }
+
+type verifyEmailVerificationCodePayload struct {
+	Email string `json:"email"`
+	Code  string `json:"code"`
+}

--- a/backend/internal/endpoints/payloads.go
+++ b/backend/internal/endpoints/payloads.go
@@ -18,10 +18,12 @@ type emailListPayload struct {
 }
 
 type createEmailVerificationCodePayload struct {
-	Email string `json:"email"`
+	UserID string `json:"user_id"`
+	Email  string `json:"email"`
 }
 
 type verifyEmailVerificationCodePayload struct {
-	Email string `json:"email"`
-	Code  string `json:"code"`
+	UserID string `json:"user_id"`
+	Email  string `json:"email"`
+	Code   string `json:"code"`
 }

--- a/backend/internal/endpoints/payloads.go
+++ b/backend/internal/endpoints/payloads.go
@@ -16,3 +16,7 @@ type clientMetadata struct {
 type emailListPayload struct {
 	Email string `json:"email"`
 }
+
+type createEmailVerificationCodePayload struct {
+	Email string `json:"email"`
+}

--- a/backend/internal/redis/redis.go
+++ b/backend/internal/redis/redis.go
@@ -1,0 +1,45 @@
+package redis
+
+import (
+	"boshi-backend/internal/logger"
+	"log/slog"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/redis/go-redis/v9"
+)
+
+var log = logger.GetLogger()
+var redisOpt *redis.Options
+var redisClient *redis.Client
+var once sync.Once
+
+const EmailVerficationCodeKey = "email-verification-code"
+
+var EmailVerificationCodeTTL = time.Duration(10) * time.Minute
+
+func init() {
+	var err error
+	redisOpt, err = redis.ParseURL(os.Getenv("REDIS_URL"))
+	if err != nil {
+		log.Error("Failed to parse Redis URL", slog.Any("error", err))
+		panic(err)
+	}
+}
+
+func GetClient() *redis.Client {
+	once.Do(func() {
+		redisClient = redis.NewClient(redisOpt)
+	})
+	return redisClient
+}
+
+func CloseRedis() {
+	if redisClient != nil {
+		err := redisClient.Close()
+		if err != nil {
+			log.Error("Failed to close Redis client", slog.Any("error", err))
+		}
+	}
+}

--- a/backend/internal/redis/redis.go
+++ b/backend/internal/redis/redis.go
@@ -5,7 +5,6 @@ import (
 	"log/slog"
 	"os"
 	"sync"
-	"time"
 
 	"github.com/redis/go-redis/v9"
 )
@@ -14,10 +13,6 @@ var log = logger.GetLogger()
 var redisOpt *redis.Options
 var redisClient *redis.Client
 var once sync.Once
-
-const EmailVerficationCodeKey = "email-verification-code"
-
-var EmailVerificationCodeTTL = time.Duration(10) * time.Minute
 
 func init() {
 	var err error
@@ -28,6 +23,7 @@ func init() {
 	}
 }
 
+// Retrieves a singleton instance of the Redis client.
 func GetClient() *redis.Client {
 	once.Do(func() {
 		redisClient = redis.NewClient(redisOpt)
@@ -35,6 +31,8 @@ func GetClient() *redis.Client {
 	return redisClient
 }
 
+// Closes redis connection. Should only be called when the
+// application is shutting down.
 func CloseRedis() {
 	if redisClient != nil {
 		err := redisClient.Close()

--- a/backend/internal/sqlc/models.go
+++ b/backend/internal/sqlc/models.go
@@ -8,7 +8,13 @@ import (
 	"github.com/jackc/pgx/v5/pgtype"
 )
 
-type EmailList struct {
+type Email struct {
+	Email      string
+	CreatedAt  pgtype.Timestamptz
+	VerifiedAt pgtype.Timestamptz
+}
+
+type MailList struct {
 	Email     string
 	CreatedAt pgtype.Timestamptz
 }

--- a/backend/internal/sqlc/models.go
+++ b/backend/internal/sqlc/models.go
@@ -5,8 +5,54 @@
 package sqlc
 
 import (
+	"database/sql/driver"
+	"fmt"
+
 	"github.com/jackc/pgx/v5/pgtype"
 )
+
+type VerificationStatus string
+
+const (
+	VerificationStatusNoMatch         VerificationStatus = "no_match"
+	VerificationStatusAlreadyVerified VerificationStatus = "already_verified"
+	VerificationStatusJustVerified    VerificationStatus = "just_verified"
+)
+
+func (e *VerificationStatus) Scan(src interface{}) error {
+	switch s := src.(type) {
+	case []byte:
+		*e = VerificationStatus(s)
+	case string:
+		*e = VerificationStatus(s)
+	default:
+		return fmt.Errorf("unsupported scan type for VerificationStatus: %T", src)
+	}
+	return nil
+}
+
+type NullVerificationStatus struct {
+	VerificationStatus VerificationStatus
+	Valid              bool // Valid is true if VerificationStatus is not NULL
+}
+
+// Scan implements the Scanner interface.
+func (ns *NullVerificationStatus) Scan(value interface{}) error {
+	if value == nil {
+		ns.VerificationStatus, ns.Valid = "", false
+		return nil
+	}
+	ns.Valid = true
+	return ns.VerificationStatus.Scan(value)
+}
+
+// Value implements the driver Valuer interface.
+func (ns NullVerificationStatus) Value() (driver.Value, error) {
+	if !ns.Valid {
+		return nil, nil
+	}
+	return string(ns.VerificationStatus), nil
+}
 
 type Email struct {
 	UserID     string

--- a/backend/internal/sqlc/models.go
+++ b/backend/internal/sqlc/models.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Email struct {
+	UserID     string
 	Email      string
 	CreatedAt  pgtype.Timestamptz
 	VerifiedAt pgtype.Timestamptz

--- a/backend/internal/sqlc/query.sql.go
+++ b/backend/internal/sqlc/query.sql.go
@@ -20,8 +20,10 @@ func (q *Queries) AddToMailList(ctx context.Context, email string) error {
 
 const upsertEmail = `-- name: UpsertEmail :one
 INSERT INTO emails (user_id, email)
-VALUES ($1, $2) ON CONFLICT (user_id) DO UPDATE
+VALUES ($1, $2)
+ON CONFLICT (user_id) DO UPDATE
 SET email = EXCLUDED.email
+WHERE emails.verified_at IS NULL
 RETURNING user_id, email, created_at, verified_at
 `
 

--- a/backend/internal/sqlc/query.sql.go
+++ b/backend/internal/sqlc/query.sql.go
@@ -32,11 +32,12 @@ func (q *Queries) AddUnverifiedEmail(ctx context.Context, email string) (Email, 
 	return i, err
 }
 
-const verifyEmail = `-- name: VerifyEmail :exec
-UPDATE emails SET verified_at = NOW() WHERE email = $1
+const verifyEmail = `-- name: VerifyEmail :one
+UPDATE emails SET verified_at = NOW() WHERE email = $1 RETURNING email
 `
 
-func (q *Queries) VerifyEmail(ctx context.Context, email string) error {
-	_, err := q.db.Exec(ctx, verifyEmail, email)
-	return err
+func (q *Queries) VerifyEmail(ctx context.Context, email string) (string, error) {
+	row := q.db.QueryRow(ctx, verifyEmail, email)
+	err := row.Scan(&email)
+	return email, err
 }

--- a/backend/query.sql
+++ b/backend/query.sql
@@ -3,9 +3,12 @@ INSERT INTO mail_list (email) VALUES ($1);
 
 -- name: UpsertEmail :one
 INSERT INTO emails (user_id, email)
-VALUES ($1, $2) ON CONFLICT (user_id) DO UPDATE
+VALUES ($1, $2)
+ON CONFLICT (user_id) DO UPDATE
 SET email = EXCLUDED.email
+WHERE emails.verified_at IS NULL
 RETURNING *;
+
 
 -- name: VerifyEmail :one
 WITH matched AS (

--- a/backend/query.sql
+++ b/backend/query.sql
@@ -7,5 +7,5 @@ VALUES ($1) ON CONFLICT (email) DO UPDATE
 SET email = EXCLUDED.email
 RETURNING *;
 
--- name: VerifyEmail :exec
-UPDATE emails SET verified_at = NOW() WHERE email = $1;
+-- name: VerifyEmail :one
+UPDATE emails SET verified_at = NOW() WHERE email = $1 RETURNING email;

--- a/backend/query.sql
+++ b/backend/query.sql
@@ -1,2 +1,11 @@
--- name: InsertEmail :exec
-INSERT INTO email_list (email) VALUES ($1);
+-- name: AddToMailList :exec
+INSERT INTO mail_list (email) VALUES ($1);
+
+-- name: AddUnverifiedEmail :one
+INSERT INTO emails (email)
+VALUES ($1) ON CONFLICT (email) DO UPDATE
+SET email = EXCLUDED.email
+RETURNING *;
+
+-- name: VerifyEmail :exec
+UPDATE emails SET verified_at = NOW() WHERE email = $1;

--- a/backend/query.sql
+++ b/backend/query.sql
@@ -1,11 +1,14 @@
 -- name: AddToMailList :exec
 INSERT INTO mail_list (email) VALUES ($1);
 
--- name: AddUnverifiedEmail :one
-INSERT INTO emails (email)
-VALUES ($1) ON CONFLICT (email) DO UPDATE
+-- name: UpsertEmail :one
+INSERT INTO emails (user_id, email)
+VALUES ($1, $2) ON CONFLICT (user_id) DO UPDATE
 SET email = EXCLUDED.email
 RETURNING *;
 
 -- name: VerifyEmail :one
-UPDATE emails SET verified_at = NOW() WHERE email = $1 RETURNING email;
+UPDATE emails
+SET verified_at = NOW()
+WHERE user_id = $1 AND email = $2
+RETURNING email;

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -37,8 +37,10 @@ CREATE TABLE mail_list (
 );
 
 CREATE TABLE emails (
+    user_id VARCHAR NOT NULL,
     email VARCHAR NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
     verified_at TIMESTAMPTZ,
-    PRIMARY KEY (email)
+    PRIMARY KEY (user_id),
+    UNIQUE (email)
 );

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -36,6 +36,8 @@ CREATE TABLE mail_list (
     PRIMARY KEY (email)
 );
 
+CREATE TYPE verification_status AS ENUM ('no_match', 'already_verified', 'just_verified');
+
 CREATE TABLE emails (
     user_id VARCHAR NOT NULL,
     email VARCHAR NOT NULL,

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -30,8 +30,15 @@ CREATE TABLE reaction (
     FOREIGN KEY (post_uri) REFERENCES post (uri) ON DELETE CASCADE
 );
 
-CREATE TABLE email_list (
+CREATE TABLE mail_list (
     email VARCHAR NOT NULL,
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
     PRIMARY KEY (email)
 );
+
+CREATE TABLE emails (
+    email VARCHAR NOT NULL,
+    created_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
+    verified_at TIMESTAMPTZ,
+    PRIMARY KEY (email)
+)

--- a/backend/schema.sql
+++ b/backend/schema.sql
@@ -41,4 +41,4 @@ CREATE TABLE emails (
     created_at TIMESTAMPTZ NOT NULL DEFAULT NOW (),
     verified_at TIMESTAMPTZ,
     PRIMARY KEY (email)
-)
+);

--- a/kubernetes/backend.yaml
+++ b/kubernetes/backend.yaml
@@ -23,6 +23,8 @@ spec:
               value: "80"
             - name: POSTGRES_URL
               value: ${POSTGRES_URL}
+            - name: REDIS_URL
+              value: ${REDIS_URL}
             - name: SMTP_FROM
               value: ${SMTP_FROM}
             - name: SMTP_HOST


### PR DESCRIPTION
# Description

Added two endpoints for handling email code verification.

- `POST /email/code` - creates a code for the given email in the payload. Will 1) insert the email idempotently and 2) add a code in redis associated with the email
- `POST /email/verify` - verifies the code associated with the email.


## Type of change

Please delete options that are not relevant.

-   [x] New feature (non-breaking change which adds functionality)
