### PR TITLE
fix: rename feed generator uri to correct name

### DIFF
--- a/frontend/lib/config/environment.dart
+++ b/frontend/lib/config/environment.dart
@@ -9,7 +9,7 @@ class EnvironmentConfig {
     defaultValue: false,
   );
   static const feedGenUri = String.fromEnvironment(
-    'FEED_GEN_URI',
+    'FEED_GENERATOR_URI',
     defaultValue: '',
   );
 }


### PR DESCRIPTION
# Description

The home page was broken because the feed was not being properly retrieved. This is because the variable for the feed generator uri had the incorrect name for the environment variable. This PR renamed the variable to reference the correct name and fixes the home page.

## Type of change

Please delete options that are not relevant.

-   [x] Bug fix (non-breaking change which fixes an issue)