### PR TITLE
refactor: add loading indicator and error screen for home

### DIFF
--- a/frontend/.env.example
+++ b/frontend/.env.example
@@ -1,4 +1,4 @@
-BACKEND_HOST=
-BACKEND_PORT=
+BACKEND_BASE_URL=http://localhost:8080
 FRONTEND_PORT=3000
-FEED_GENERATOR_URI='at://did:example:alice/app.bsky.feed.generator/boshi'
+FEED_GENERATOR_URI='at://did:plc:alice/app.bsky.feed.generator/boshi'
+PROD=false

--- a/frontend/Makefile
+++ b/frontend/Makefile
@@ -1,4 +1,4 @@
-.PHONY: docker docker-push staging types all format
+.PHONY: all run types docker docker-push compose-build docker-network dev format clean
 
 DOCKER_REGISTRY ?= matthew10125
 IMAGE_NAME ?= boshi-frontend
@@ -15,9 +15,19 @@ ifneq (,$(wildcard ./.env))
     export
 endif
 
+all: run
+
 run:
-	scripts/start.sh &
-	flutter run -d $(DEVICE_ID) --target $(MAIN_TARGET) --pid-file /tmp/flutter.pid --web-hostname 127.0.0.1 --web-port $(FRONTEND_PORT)
+	# scripts/start.sh &
+	flutter run -d $(DEVICE_ID) \
+	--target $(MAIN_TARGET) \
+	--pid-file /tmp/flutter.pid \
+	--web-hostname 127.0.0.1 \
+	--web-port $(FRONTEND_PORT) \
+	--dart-define=BACKEND_BASE_URL=$(BACKEND_BASE_URL) \
+	--dart-define=FRONTEND_PORT=$(FRONTEND_PORT) \
+	--dart-define=PROD=$(PROD) \
+	--dart-define=FEED_GENERATOR_URI=$(FEED_GENERATOR_URI)
 
 types:
 	dart run build_runner watch -d

--- a/frontend/lib/ui/core/ui/error.dart
+++ b/frontend/lib/ui/core/ui/error.dart
@@ -8,11 +8,14 @@ class Error extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
-    return Text(
-      message,
-      style: TextStyle(
-        color: color ?? Colors.red,
-        fontSize: 14,
+    return SizedBox(
+      width: 350,
+      child: Text(
+        message,
+        style: TextStyle(
+          color: color ?? Colors.red,
+          fontSize: 14,
+        ),
       ),
     );
   }

--- a/frontend/lib/ui/home/view_model/home_viewmodel.dart
+++ b/frontend/lib/ui/home/view_model/home_viewmodel.dart
@@ -50,6 +50,11 @@ class HomeViewModel extends ChangeNotifier {
     }
   }
 
+  void reload() {
+    load = Command0(_load)..execute();
+    notifyListeners();
+  }
+
   Future<Result<Post>> _updateReactionCount(
     ReactionPayload reactionPayload,
   ) async {

--- a/frontend/lib/ui/home/widgets/home_screen.dart
+++ b/frontend/lib/ui/home/widgets/home_screen.dart
@@ -2,6 +2,10 @@ import 'package:flutter/material.dart';
 
 import 'package:frontend/ui/core/ui/header.dart';
 import 'package:frontend/ui/core/ui/footer.dart';
+import 'package:frontend/ui/core/ui/error_screen.dart';
+import 'package:frontend/internal/result/result.dart';
+import 'package:frontend/internal/exceptions/format.dart';
+import 'package:frontend/internal/logger/logger.dart';
 
 import '../view_model/home_viewmodel.dart';
 import 'feed.dart';
@@ -19,6 +23,16 @@ class HomeScreen extends StatelessWidget {
         body: ListenableBuilder(
           listenable: viewModel,
           builder: (context, _) {
+            if (viewModel.load.running) {
+              return const Center(child: CircularProgressIndicator());
+            } else if (viewModel.load.error) {
+              final result = viewModel.load.result! as Error;
+              return ErrorScreen(
+                message: formatExceptionMsg(result.error),
+                onRefresh: viewModel.reload,
+              );
+            }
+
             return Column(
               children: [
                 Header(title: title),


### PR DESCRIPTION
# Description

Previously, when the home screen was loading posts the default screen would display "No posts yet!". This PR introduces a loading indicator when retrieving posts and an error screen when an error is faced. Some minor changes to the makefile are also made.

## Type of change

Please delete options that are not relevant

-   [x] New feature (non-breaking change which adds functionality)